### PR TITLE
Ryan Casperson - Complete the test writing assignment

### DIFF
--- a/tests/e2e/specs/common.js
+++ b/tests/e2e/specs/common.js
@@ -1,0 +1,14 @@
+export const errorMessages = {
+  failedAuth: 'Invalid email or password',
+  invalidEmail: 'Invalid email format',
+  missingPassword: 'Must provide a password',
+  missingFullName: 'Full name is required',
+  invalidPassword: 'Password must be greater than 8 characters',
+  passwordMismatch: 'Password confirmation does not match password'
+}
+
+export const invalidEmailAddresses = [
+  'just-a-work',
+  '@onlydomain.com',
+  'missing@extension'
+]

--- a/tests/e2e/specs/login.js
+++ b/tests/e2e/specs/login.js
@@ -27,8 +27,6 @@ const nonExistentAccountCreds = {
 }
 
 const login = (email, password) => {
-  cy.visit('/login')
-
   if (email) {
     cy.get(page_elements.inputs.email)
       .clear()
@@ -50,10 +48,12 @@ const validateErrorMessage = expectedMessage => {
 }
 
 describe('The login page', () => {
-  it('Should contain the required fields', () => {
+  beforeEach(() => {
     // Navigate to login form
     cy.visit('/login')
+  })
 
+  it('Should contain the required fields', () => {
     // Assert that form elements exist
     cy.get(page_elements.inputs.email).should('exist')
     cy.get(page_elements.inputs.password).should('exist')

--- a/tests/e2e/specs/login.js
+++ b/tests/e2e/specs/login.js
@@ -1,3 +1,5 @@
+import { errorMessages, invalidEmailAddresses } from './common'
+
 const page_elements = {
   inputs: {
     email: '[data-cy="input-email"]',
@@ -23,18 +25,6 @@ const nonExistentAccountCreds = {
   email: 'correctly@formatted.com',
   password: 'arbitrarypass123'
 }
-
-const errorMessages = {
-  failedAuth: 'Invalid email or password',
-  invalidEmail: 'Invalid email format',
-  missingPassword: 'Must provide a password'
-}
-
-const invalidEmailAddresses = [
-  'just-a-work',
-  '@onlydomain.com',
-  'missing@extension'
-]
 
 const login = (email, password) => {
   cy.visit('/login')

--- a/tests/e2e/specs/login.js
+++ b/tests/e2e/specs/login.js
@@ -7,8 +7,56 @@ const page_elements = {
     login: '[data-cy="button-login"]'
   },
   text: {
-    register: '[data-cy="text-register"]'
+    register: '[data-cy="text-register"]',
+    success: '[data-cy="text-success"]',
+    error: '[data-cy="text-error"]'
   }
+}
+
+const existingAccountCreds = {
+  email: 'super@secret.com',
+  password: '1234567890',
+  incorrectPassword: 'abcdefg'
+}
+
+const nonExistentAccountCreds = {
+  email: 'correctly@formatted.com',
+  password: 'arbitrarypass123'
+}
+
+const errorMessages = {
+  failedAuth: 'Invalid email or password',
+  invalidEmail: 'Invalid email format',
+  missingPassword: 'Must provide a password'
+}
+
+const invalidEmailAddresses = [
+  'just-a-work',
+  '@onlydomain.com',
+  'missing@extension'
+]
+
+const login = (email, password) => {
+  cy.visit('/login')
+
+  if (email) {
+    cy.get(page_elements.inputs.email)
+      .clear()
+      .type(email)
+  }
+
+  if (password) {
+    cy.get(page_elements.inputs.password)
+      .clear()
+      .type(password)
+  }
+
+  // Initiate the login
+  cy.get(page_elements.buttons.login).click()
+}
+
+const validateErrorMessage = expectedMessage => {
+  cy.get(page_elements.text.error).should('contain', expectedMessage)
 }
 
 describe('The login page', () => {
@@ -25,5 +73,51 @@ describe('The login page', () => {
     cy.get(page_elements.text.register)
       .should('exist')
       .should('contain', "Don't have an account yet?")
+  })
+
+  it('Should login successfully with correct credentials', () => {
+    login(existingAccountCreds.email, existingAccountCreds.password)
+
+    // Assert that the login was successful
+    cy.get(page_elements.text.success)
+      .should('exist')
+      .should('contain', 'You have been successfully logged in!')
+  })
+
+  it('Should error when logging in with an incorrect password', () => {
+    login(existingAccountCreds.email, existingAccountCreds.incorrectPassword)
+    validateErrorMessage(errorMessages.failedAuth)
+  })
+
+  it('Should error when logging in with a non-existent account', () => {
+    login(nonExistentAccountCreds.email, nonExistentAccountCreds.password)
+    validateErrorMessage(errorMessages.failedAuth)
+  })
+
+  it('Should error when logging in with a missing email address', () => {
+    login('', existingAccountCreds.password)
+    validateErrorMessage(errorMessages.invalidEmail)
+  })
+
+  for (let invalidEmailAddress of invalidEmailAddresses) {
+    it(`Should error when logging in with an invalid email address - ${invalidEmailAddress}`, () => {
+      login(invalidEmailAddress, existingAccountCreds.password)
+      validateErrorMessage(errorMessages.invalidEmail)
+    })
+  }
+
+  it('Should error when logging in with a missing password', () => {
+    login(existingAccountCreds.email, '')
+    validateErrorMessage(errorMessages.missingPassword)
+  })
+
+  it('Should provide a working link to the Register page', () => {
+    // Click the register button
+    cy.get(page_elements.text.register)
+      .get('a')
+      .click()
+
+    // Assert the register page was loaded
+    cy.location('pathname').should('eq', '/register')
   })
 })

--- a/tests/e2e/specs/register.js
+++ b/tests/e2e/specs/register.js
@@ -1,5 +1,174 @@
-// https://docs.cypress.io/api/introduction/api.html
+const page_elements = {
+  inputs: {
+    fullName: '[data-cy="input-full-name"]',
+    email: '[data-cy="input-email"]',
+    password: '[data-cy="input-password"]',
+    passwordConfirmation: '[data-cy="input-password-confirmation"]'
+  },
+  buttons: {
+    register: '[data-cy="button-register"]'
+  },
+  text: {
+    login: '[data-cy="text-login"]',
+    success: '[data-cy="text-success"]',
+    error: '[data-cy="text-error"]'
+  }
+}
+
+const validNewUserData = {
+  fullName: 'John Doe',
+  email: 'john@doe.com',
+  password: 'password-greater-than-8-chars'
+}
+
+const errorMessages = {
+  invalidEmail: 'Invalid email format',
+  missingFullName: 'Full name is required',
+  invalidPassword: 'Password must be greater than 8 characters',
+  passwordMismatch: 'Password confirmation does not match password'
+}
+
+const invalidEmailAddresses = [
+  'just-a-work',
+  '@onlydomain.com',
+  'missing@extension'
+]
+
+const register = (fullName, email, password, passwordConfirmation) => {
+  cy.visit('/register')
+
+  if (fullName) {
+    cy.get(page_elements.inputs.fullName)
+      .clear()
+      .type(fullName)
+  }
+
+  if (email) {
+    cy.get(page_elements.inputs.email)
+      .clear()
+      .type(email)
+  }
+
+  if (password) {
+    cy.get(page_elements.inputs.password)
+      .clear()
+      .type(password)
+  }
+
+  if (passwordConfirmation) {
+    cy.get(page_elements.inputs.passwordConfirmation)
+      .clear()
+      .type(passwordConfirmation)
+  }
+
+  // Initiate the registration
+  cy.get(page_elements.buttons.register).click()
+}
+
+const validateErrorMessage = expectedMessage => {
+  cy.get(page_elements.text.error).should('contain', expectedMessage)
+}
 
 describe('The registration page', () => {
-  // TODO: Add it blocks for your various test cases
+  it('Should contain the required fields', () => {
+    // Navigate to login form
+    cy.visit('/register')
+
+    // Assert that form elements exist
+    cy.get(page_elements.inputs.fullName).should('exist')
+    cy.get(page_elements.inputs.email).should('exist')
+    cy.get(page_elements.inputs.password).should('exist')
+    cy.get(page_elements.inputs.passwordConfirmation).should('exist')
+    cy.get(page_elements.buttons.register).should('exist')
+
+    // Assert that the registration form is accessible
+    cy.get(page_elements.text.login)
+      .should('exist')
+      .should('contain', 'Already have an account?')
+  })
+
+  it('Should login successfully with correct credentials', () => {
+    register(
+      validNewUserData.fullName,
+      validNewUserData.email,
+      validNewUserData.password,
+      validNewUserData.password
+    )
+
+    // Assert that the login was successful
+    cy.get(page_elements.text.success)
+      .should('exist')
+      .should('contain', 'You have successfully registered!')
+  })
+
+  it('Should error when registering with a missing Full Name', () => {
+    register(
+      '',
+      validNewUserData.email,
+      validNewUserData.password,
+      validNewUserData.password
+    )
+    validateErrorMessage(errorMessages.missingFullName)
+  })
+
+  it('Should error when registering with a missing email', () => {
+    register(
+      validNewUserData.fullName,
+      '',
+      validNewUserData.password,
+      validNewUserData.password
+    )
+    validateErrorMessage(errorMessages.invalidEmail)
+  })
+
+  it('Should error when registering with a missing password', () => {
+    register(validNewUserData.fullName, validNewUserData.email, '', '')
+    validateErrorMessage(errorMessages.invalidPassword)
+  })
+
+  it('Should error when registering with a password that is too short', () => {
+    const minPasswordLength = 8
+    const tooShortPass = new Array(minPasswordLength).join('a')
+    register(
+      validNewUserData.fullName,
+      validNewUserData.email,
+      tooShortPass,
+      tooShortPass
+    )
+    validateErrorMessage(errorMessages.invalidPassword)
+  })
+
+  for (let invalidEmailAddress of invalidEmailAddresses) {
+    it(`Should error when registering with an invalid email - ${invalidEmailAddress}`, () => {
+      register(
+        validNewUserData.fullName,
+        invalidEmailAddress,
+        validNewUserData.password,
+        validNewUserData.password
+      )
+      validateErrorMessage(errorMessages.invalidEmail)
+    })
+  }
+
+  it('Should error when registering with mismatched passwords', () => {
+    register(
+      validNewUserData.fullName,
+      validNewUserData.email,
+      validNewUserData.password,
+      validNewUserData.password + 'more'
+    )
+    validateErrorMessage(errorMessages.passwordMismatch)
+  })
+
+  it('Should provide a working link to the Login page', () => {
+    cy.visit('/register')
+
+    // Click the login button
+    cy.get(page_elements.text.login)
+      .get('a')
+      .click()
+
+    // Assert the Login page was loaded
+    cy.location('pathname').should('eq', '/login')
+  })
 })

--- a/tests/e2e/specs/register.js
+++ b/tests/e2e/specs/register.js
@@ -1,3 +1,5 @@
+import { errorMessages, invalidEmailAddresses } from './common'
+
 const page_elements = {
   inputs: {
     fullName: '[data-cy="input-full-name"]',
@@ -20,19 +22,6 @@ const validNewUserData = {
   email: 'john@doe.com',
   password: 'password-greater-than-8-chars'
 }
-
-const errorMessages = {
-  invalidEmail: 'Invalid email format',
-  missingFullName: 'Full name is required',
-  invalidPassword: 'Password must be greater than 8 characters',
-  passwordMismatch: 'Password confirmation does not match password'
-}
-
-const invalidEmailAddresses = [
-  'just-a-work',
-  '@onlydomain.com',
-  'missing@extension'
-]
 
 const register = (fullName, email, password, passwordConfirmation) => {
   cy.visit('/register')

--- a/tests/e2e/specs/register.js
+++ b/tests/e2e/specs/register.js
@@ -24,8 +24,6 @@ const validNewUserData = {
 }
 
 const register = (fullName, email, password, passwordConfirmation) => {
-  cy.visit('/register')
-
   if (fullName) {
     cy.get(page_elements.inputs.fullName)
       .clear()
@@ -59,10 +57,12 @@ const validateErrorMessage = expectedMessage => {
 }
 
 describe('The registration page', () => {
-  it('Should contain the required fields', () => {
+  beforeEach(() => {
     // Navigate to login form
     cy.visit('/register')
+  })
 
+  it('Should contain the required fields', () => {
     // Assert that form elements exist
     cy.get(page_elements.inputs.fullName).should('exist')
     cy.get(page_elements.inputs.email).should('exist')
@@ -150,8 +150,6 @@ describe('The registration page', () => {
   })
 
   it('Should provide a working link to the Login page', () => {
-    cy.visit('/register')
-
     // Click the login button
     cy.get(page_elements.text.login)
       .get('a')


### PR DESCRIPTION
@akoutmos, you'll find my solution as requested here in this PR. I kept the full commit history as I thought it useful to show how I came to the final solution.

I tried to keep to the scope of adding to the current Login page tests and implementing the Register page tests. I think it is important to keep PRs as small as possible, and to a limited scope.

For this work, one idea that I'd typically put into a "fast follow" PR would be to move to a Page Object model, where the selectors are stored on a page class, and methods on that same class will perform actions, like the `login` and `register` helper functions. This would help isolate the actions from the assertions more, and would be much easier to use if more tests needed to be included that would reuse the functionality.